### PR TITLE
add support for x-forwarded-host

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function getAuthServerUrl(options, originalUrl) {
  * @returns {string}
  */
 function getOriginalUrl(req) {
-  const host = req.get('host'); // includes port on Chrome, needed for dev
+  const host = req.get('x-forwarded-host') || req.get('host'); // includes port on Chrome, needed for dev
 
   return req.protocol + '://' + host + req.originalUrl;
 }


### PR DESCRIPTION
This is needed for non-local clay instances behind varnish or other proxies.
